### PR TITLE
[DEVOPS-3816] fix: add missing required vaultId + update go-dvls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.21 as builder
+FROM golang:1.21 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/config/crd/bases/dvls.devolutions.com_dvlssecrets.yaml
+++ b/config/crd/bases/dvls.devolutions.com_dvlssecrets.yaml
@@ -37,8 +37,11 @@ spec:
             properties:
               entryId:
                 type: string
+              vaultId:
+                type: string
             required:
             - entryId
+            - vaultId
             type: object
           status:
             description: DvlsSecretStatus defines the observed state of DvlsSecret

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.21
 toolchain go1.21.4
 
 require (
-	github.com/Devolutions/go-dvls v0.12.2
+	github.com/Devolutions/go-dvls v0.13.0
 	github.com/onsi/ginkgo/v2 v2.14.0
 	github.com/onsi/gomega v1.30.0
 	k8s.io/api v0.29.1

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Devolutions/go-dvls v0.12.2 h1:7qptA5gw8JVtEJuTBmfDHOFfkGY6XMRobvg6InIEa+4=
-github.com/Devolutions/go-dvls v0.12.2/go.mod h1:4O3lb/RK1P1cDwU5auVi7CM4gRER7EuwyLwMVuEZjgg=
+github.com/Devolutions/go-dvls v0.13.0 h1:ct0UByARy4ZUOUE2+caUlT8cnkIl+8PXtKJOnox+YOw=
+github.com/Devolutions/go-dvls v0.13.0/go.mod h1:4O3lb/RK1P1cDwU5auVi7CM4gRER7EuwyLwMVuEZjgg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=


### PR DESCRIPTION
pour réglé un problème que j'avais pendant ma vidéo de démo, le vaultID est required