### PR TITLE
[DEVOPS-4325] ci: add cosign keyless signing and provenance to docker image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Set version
         id: get-version
-        run: echo "version=$(grep -E '^VERSION[[:space:]]*\?=' Makefile | awk -F'= ' '{print $2}' | tr -d ' ')" >> $GITHUB_OUTPUT
+        run: echo "version=$(grep -E '^VERSION[[:space:]]*\?=' Makefile | awk -F'= ' '{print $2}' | tr -d ' ')" >> "$GITHUB_OUTPUT"
 
       - name: Create release
         uses: ./.github/workflows/create-release
@@ -35,10 +35,15 @@ jobs:
     runs-on: ubuntu-latest
     needs: create-release
     environment: container-build
+    permissions:
+      id-token: write
 
     steps:
       - name: Check out devolutions/dvls-kubernetes-operator
         uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
         uses: docker/login-action@v3
@@ -48,13 +53,23 @@ jobs:
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v6
         with:
           context: .
+          provenance: mode=max
           push: true
+          sbom: true
           tags: |
             devolutions/dvls-kubernetes-operator:latest
             devolutions/dvls-kubernetes-operator:${{ needs.create-release.outputs.version }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v4.0.0
+
+      - name: Sign image with Cosign
+        run: |
+          cosign sign --yes --recursive \
+            devolutions/dvls-kubernetes-operator@${{ steps.docker_build.outputs.digest }}
 
       - name: Docker Scout
         uses: docker/scout-action@v1


### PR DESCRIPTION
## Summary
- Upgrade to `docker/build-push-action@v6` and add `docker/setup-buildx-action@v3`
- Add SLSA provenance (`provenance: mode=max`) and SBOM attestation (`sbom: true`)
- Add keyless Cosign image signing using `sigstore/cosign-installer@v4.0.0` with OIDC identity
- Add `id-token: write` permission for Fulcio/Rekor keyless flow